### PR TITLE
v0.3.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ Redback-JAX reimplements redback's analytical transient models in JAX, using log
 - **JIT-compiled and differentiable**: Every model is decorated with `@jax.jit`; gradients flow through the full pipeline via `jax.grad`
 - **`vmap`-based diffusion integrals**: Arnett-style diffusion uses `jax.vmap` over time points with log-mirror quadrature nodes
 - **Spectra pipeline**: `make_spectra_model(bolometric_fn)` wraps any bolometric model to produce time × wavelength spectra for bandflux/magnitude comparison
-- **Inference-ready**: Compatible with BlackJAX (NUTS, SMC) and flowMC (MALA/NF) samplers
+- **Clean inference API**: `Prior`, `Likelihood`, `NestedSampler`, and `MCMCSampler` — compose a full Bayesian fit in ~15 lines
+- **Multi-sampler support**: BlackJAX NUTS (MCMC) and nested sampling via `blackjax.nss`
 
 ## Models
 
@@ -64,50 +65,77 @@ log10_lbol_model = arnett_bolometric(time, f_nickel=0.5, mej=1.0,
 log_like = -0.5 * jnp.sum(((log10_lbol_obs - log10_lbol_model) / log10_lbol_err)**2)
 ```
 
-## Fitting spectra / photometry
+## Bayesian inference — photometric fitting
+
+The `Prior` / `Likelihood` / `NestedSampler` / `MCMCSampler` API handles the full pipeline: model evaluation, bandflux integration, and sampling.
 
 ```python
-import jax; jax.config.update("jax_enable_x64", False)  # stay in float32
-import jax.numpy as jnp
-from redback_jax.models.supernova_models import arnett_bolometric
-from redback_jax.models.spectra_model import make_spectra_model
+import jax
+from redback_jax.inference import Prior, Uniform, Likelihood, NestedSampler, MCMCSampler
+from redback_jax.utils import luminosity_distance_cm
+
+REDSHIFT = 0.01
+DL_CM    = luminosity_distance_cm(REDSHIFT)   # ~1.37e26 cm
+
+# Free parameters
+prior = Prior([
+    Uniform(58580, 58620,  name='t0'),        # MJD explosion epoch
+    Uniform(0.05,  0.30,   name='f_nickel'),
+    Uniform(0.5,   3.0,    name='mej'),
+    Uniform(3000,  12000,  name='vej'),
+])
+
+# Likelihood — transient.time (MJD), transient.y (AB mag), transient.y_err, transient.bands
+likelihood = Likelihood(
+    model='arnett_spectra',
+    transient=transient,
+    fixed_params={
+        'redshift':          REDSHIFT,
+        'lum_dist':          DL_CM,
+        'temperature_floor': 5000.0,
+        'kappa':             0.07,
+        'kappa_gamma':       0.1,
+    },
+)
+
+# Nested sampling (BlackJAX)
+ns_result = NestedSampler(likelihood, prior, outdir='results/').run(jax.random.PRNGKey(0))
+ns_result.summary()
+
+# Or MCMC with NUTS (BlackJAX)
+mcmc_result = MCMCSampler(likelihood, prior, n_warmup=500, n_samples=2000, n_chains=4).run(
+    jax.random.PRNGKey(1)
+)
+mcmc_result.summary()
+```
+
+### Available models
+
+Pass any string from `redback_jax.models.MODELS` as the `model` argument:
+
+```python
+from redback_jax.models import MODELS
+print(list(MODELS.keys()))
+# ['arnett_spectra', 'magnetar_spectra', 'csm_spectra', ...]
+```
+
+## Direct spectra / magnitude evaluation
+
+To compute magnitudes outside of inference (e.g. for plotting):
+
+```python
 from redback_jax.sources import PrecomputedSpectraSource
+from redback_jax.utils import luminosity_distance_cm
 
-# Build spectra model
-arnett_spectra = make_spectra_model(arnett_bolometric)
-
-# Compute spectra grid once (at fixed parameters for PrecomputedSpectraSource)
-output = arnett_spectra(
-    redshift=0.05,
-    lum_dist=7e26,          # cm (~230 Mpc)
-    vej_kms=10000.0,
-    temperature_floor=3000.0,
-    f_nickel=0.5, mej=1.0,
-    vej=10000.0, kappa=0.1, kappa_gamma=10.0,
+source = PrecomputedSpectraSource.from_arnett_model(
+    f_nickel=0.15, mej=1.0, vej=8000.0,
+    redshift=0.01,
+    cosmo_H0=67.66, cosmo_Om0=0.3111,
 )
 
-# Create bandflux source
-source = PrecomputedSpectraSource(
-    phases=output.time,
-    wavelengths=output.lambdas,
-    flux_grid=output.spectra,
-)
-
-# Prepare bridges for fast multi-band fitting
-bridges, band_to_idx = source.prepare_bridges(['ztfg', 'ztfr', 'ztfi'])
-band_indices = jnp.array([band_to_idx[b] for b in observed_bands])
-
-@jax.jit
-def log_likelihood(params):
-    out = arnett_spectra(
-        redshift=0.05, lum_dist=7e26, vej_kms=10000.0, temperature_floor=3000.0,
-        **params,
-    )
-    src = PrecomputedSpectraSource(phases=out.time, wavelengths=out.lambdas, flux_grid=out.spectra)
-    model_mag = src.bandmag({'amplitude': 1.0}, None, obs_times,
-                             band_indices=band_indices, bridges=bridges,
-                             unique_bands=['ztfg', 'ztfr', 'ztfi'])
-    return -0.5 * jnp.sum(((obs_mags - model_mag) / obs_errs)**2)
+# AB magnitude in ztfr at a set of phases
+phases = jnp.linspace(-5, 40, 200)
+mags   = source.bandmag({'amplitude': 1.0}, 'ztfr', phases)
 ```
 
 ## Parameter conventions

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -1,19 +1,158 @@
 Examples
 ========
 
-This section will contain examples and tutorials for using redback-jax.
+Bolometric inference with BlackJAX
+------------------------------------
 
-Basic Examples
---------------
+Fit an Arnett model to observed bolometric luminosities using NUTS via BlackJAX.
+Because all bolometric models return ``log10_lbol``, the likelihood is computed
+in log10 space — this is both float32-safe and numerically well-conditioned.
 
-Coming soon: Basic usage examples for electromagnetic transient modeling.
+.. code-block:: python
 
-Advanced Examples
-----------------
+   import jax
+   jax.config.update("jax_enable_x64", False)
 
-Coming soon: Advanced tutorials for Bayesian inference and model fitting.
+   import jax.numpy as jnp
+   import blackjax
+   from redback_jax.models.supernova_models import arnett_bolometric
 
-Jupyter Notebooks
------------------
+   # Simulated observations
+   time = jnp.linspace(5.0, 60.0, 30, dtype=jnp.float32)
+   true_params = dict(f_nickel=0.4, mej=1.2, vej=9000.0, kappa=0.1, kappa_gamma=10.0)
+   log10_lbol_true = arnett_bolometric(time, **true_params)
+   log10_lbol_obs  = log10_lbol_true + 0.05 * jax.random.normal(jax.random.PRNGKey(0), time.shape)
+   sigma = jnp.full_like(time, 0.05)
 
-Coming soon: Interactive notebooks demonstrating key features.
+   # Log-likelihood in log10 space
+   @jax.jit
+   def log_likelihood(params):
+       log10_lbol = arnett_bolometric(time, **params,
+                                       vej=9000.0, kappa=0.1, kappa_gamma=10.0)
+       return -0.5 * jnp.sum(((log10_lbol_obs - log10_lbol) / sigma)**2)
+
+Photometry fitting with the inference API
+------------------------------------------
+
+Use the clean ``Prior`` / ``Likelihood`` / ``NestedSampler`` / ``MCMCSampler``
+API for end-to-end Bayesian photometric fitting.  The ``Likelihood`` class
+handles bandflux integration internally and is JIT-safe.
+
+.. code-block:: python
+
+   import jax
+   from redback_jax.inference import Prior, Uniform, Likelihood, NestedSampler, MCMCSampler
+   from redback_jax.utils import luminosity_distance_cm
+
+   REDSHIFT = 0.01
+   DL_CM    = luminosity_distance_cm(REDSHIFT)
+
+   prior = Prior([
+       Uniform(58580, 58620,  name='t0'),
+       Uniform(0.05,  0.30,   name='f_nickel'),
+       Uniform(0.5,   3.0,    name='mej'),
+       Uniform(3000,  12000,  name='vej'),
+   ])
+
+   # transient.time (MJD), transient.y (AB mag), transient.y_err, transient.bands
+   likelihood = Likelihood(
+       model='arnett_spectra',
+       transient=transient,
+       fixed_params={
+           'redshift':          REDSHIFT,
+           'lum_dist':          DL_CM,
+           'temperature_floor': 5000.0,
+           'kappa':             0.07,
+           'kappa_gamma':       0.1,
+       },
+   )
+
+   # Nested sampling
+   ns_result = NestedSampler(likelihood, prior, outdir='results/').run(jax.random.PRNGKey(0))
+   ns_result.summary()
+
+   # Or MCMC with NUTS
+   mcmc_result = MCMCSampler(
+       likelihood, prior, n_warmup=500, n_samples=2000, n_chains=4
+   ).run(jax.random.PRNGKey(1))
+   mcmc_result.summary()
+
+Kilonova bolometric fitting
+----------------------------
+
+The kilonova models use an energy-normalised ODE scan for float32 safety.
+They also return ``log10_lbol``:
+
+.. code-block:: python
+
+   import jax
+   jax.config.update("jax_enable_x64", False)
+   import jax.numpy as jnp
+   from redback_jax.models.kilonova import metzger_kilonova_bolometric
+
+   time = jnp.linspace(0.5, 20.0, 50, dtype=jnp.float32)
+
+   log10_lbol = metzger_kilonova_bolometric(
+       time,
+       mej=0.05,    # solar masses
+       vej=0.2,     # fraction of c
+       beta=3.0,    # velocity profile slope
+       kappa=1.0,   # cm^2/g
+   )
+   # Typical range: log10_lbol ~ [39, 42]
+
+Magnetar-boosted kilonova:
+
+.. code-block:: python
+
+   from redback_jax.models.kilonova import magnetar_boosted_kilonova_bolometric
+
+   log10_lbol = magnetar_boosted_kilonova_bolometric(
+       time,
+       mej=0.05, vej=0.2, beta=3.0, kappa=1.0,
+       p0=1.0,          # spin period in ms
+       bp=1.0,          # B-field in units of 1e14 G
+       mass_ns=1.4,     # neutron star mass in solar masses
+       theta_pb=0.0,    # spin-B field angle in radians
+   )
+
+Shock-powered models
+---------------------
+
+Shock cooling and cocoon models also return ``log10_lbol``. Note that
+``shock_cooling_bolometric`` takes log10 inputs for the large physical
+quantities:
+
+.. code-block:: python
+
+   import jax
+   jax.config.update("jax_enable_x64", False)
+   import jax.numpy as jnp
+   from redback_jax.models.shock_powered_models import (
+       shock_cooling_bolometric,
+       shocked_cocoon_bolometric,
+   )
+
+   time = jnp.linspace(0.1, 10.0, 50, dtype=jnp.float32)
+
+   # Inputs are log10(mass/Msun), log10(radius/cm), log10(energy/erg)
+   log10_lbol = shock_cooling_bolometric(
+       time,
+       log10_mass=-2.0,     # 0.01 solar masses
+       log10_radius=13.0,   # 1e13 cm
+       log10_energy=51.0,   # 1e51 erg
+       nn=10.0,             # outer density power-law slope
+       delta=1.1,           # inner density power-law slope
+       kappa=0.2,           # opacity in cm^2/g
+   )
+
+   log10_lbol = shocked_cocoon_bolometric(
+       time,
+       mej=0.01,
+       vej=0.1,             # fraction of c
+       eta=2.0,
+       tshock=1.0,          # seconds
+       shocked_fraction=0.5,
+       cos_theta_cocoon=0.5,
+       kappa=0.1,
+   )

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -1,78 +1,159 @@
 Quick Start
 ===========
 
-Basic Usage
------------
+Installation
+------------
 
-.. code-block:: python
+.. code-block:: bash
 
-   import redback_jax
-   from redback_jax import Transient, Spectrum
-   import numpy as np
-   
-   print(f"redback-jax version: {redback_jax.__version__}")
+   git clone https://github.com/nikhil-sarin/redback-jax.git
+   cd redback-jax
+   pip install -e .
 
-Creating Your First Transient
------------------------------
+Float32 mode (recommended for GPU)
+-----------------------------------
 
-.. code-block:: python
+Redback-JAX is designed to run in float32. Disable x64 before importing any
+JAX code::
 
-   # Generate some sample lightcurve data
-   time = np.linspace(0, 10, 20)
-   flux = 2 * np.exp(-time/5) + 0.1 * np.random.randn(20)
-   flux_err = 0.1 * np.ones(20)
-   
-   # Create a transient object
-   transient = Transient(
-       time=time,
-       y=flux,
-       y_err=flux_err,
-       data_mode='flux',
-       name='My First Transient'
-   )
-   
-   # Plot the data
-   import matplotlib.pyplot as plt
-   fig, ax = plt.subplots()
-   transient.plot_data(axes=ax)
-   plt.show()
+   import jax
+   jax.config.update("jax_enable_x64", False)
 
-Loading Data from Files
+Do **not** import ``jax_supernovae`` (jax-bandflux) before this call — it
+enables x64 at module level. Redback-JAX lazy-imports bandflux components to
+avoid this.
+
+Bolometric light curves
 -----------------------
 
-.. code-block:: python
-
-   # Load transient data from a CSV file
-   transient = Transient.from_data_file(
-       'lightcurve.csv',
-       data_mode='magnitude',
-       name='SN2023A'
-   )
-   
-   # Plot the loaded data
-   transient.plot_data(color='red', show_errors=True)
-
-Working with Spectra
---------------------
+All bolometric functions return ``log10(L)`` in erg/s — not linear luminosity.
+This is deliberate: physical luminosities (~10³⁸–10⁴⁵ erg/s) exceed the
+float32 maximum of ~3.4×10³⁸, so working in log10 space is the only way to
+stay float32-safe on GPU.
 
 .. code-block:: python
 
-   # Create a spectrum
-   wavelength = np.linspace(4000, 7000, 100)
-   flux_density = np.random.random(100)
-   
-   spectrum = Spectrum(
-       wavelength=wavelength,
-       flux_density=flux_density,
-       name='Example Spectrum'
-   )
-   
-   # Plot the spectrum
-   spectrum.plot_data(color='purple')
+   import jax
+   jax.config.update("jax_enable_x64", False)
+   import jax.numpy as jnp
+   from redback_jax.models.supernova_models import arnett_bolometric
 
-Next Steps
+   time = jnp.linspace(1.0, 100.0, 200, dtype=jnp.float32)
+
+   log10_lbol = arnett_bolometric(
+       time,
+       f_nickel=0.5,
+       mej=1.0,        # solar masses
+       vej=10000.0,    # km/s
+       kappa=0.1,      # cm^2/g
+       kappa_gamma=10.0,
+   )
+   # log10_lbol ~ [41, 43]  (physical range, float32-safe)
+
+Fitting bolometric data
+-----------------------
+
+Compare model and data in log10 space:
+
+.. code-block:: python
+
+   import jax.numpy as jnp
+   from redback_jax.models.supernova_models import arnett_bolometric
+
+   # Observed bolometric luminosities
+   log10_lbol_obs = jnp.log10(observed_lbol)
+   # Propagate fractional errors: sigma_{log10 L} = sigma_L / (L * ln10)
+   log10_lbol_err = sigma_lbol / (observed_lbol * jnp.log(10.0))
+
+   def log_likelihood(params):
+       log10_lbol_model = arnett_bolometric(time, **params)
+       return -0.5 * jnp.sum(((log10_lbol_obs - log10_lbol_model) / log10_lbol_err)**2)
+
+Spectra and photometry
+----------------------
+
+``make_spectra_model`` wraps any bolometric model into a full SED pipeline
+(photosphere → blackbody → observer-frame flux density):
+
+.. code-block:: python
+
+   import jax
+   jax.config.update("jax_enable_x64", False)
+   import jax.numpy as jnp
+   from redback_jax.models.supernova_models import arnett_bolometric
+   from redback_jax.models.spectra_model import make_spectra_model
+
+   arnett_spectra = make_spectra_model(arnett_bolometric)
+
+   output = arnett_spectra(
+       redshift=0.05,
+       lum_dist=7e26,           # cm (~230 Mpc)
+       temperature_floor=3000.0,
+       # bolometric kwargs:
+       f_nickel=0.5, mej=1.0,
+       vej=10000.0, kappa=0.1, kappa_gamma=10.0,
+   )
+
+   output.time     # observer-frame times (days)
+   output.lambdas  # wavelengths (Angstrom)
+   output.spectra  # (n_times, n_lambda)  erg/s/cm^2/Angstrom
+
+For bandflux fitting, pass the spectra grid to ``PrecomputedSpectraSource``:
+
+.. code-block:: python
+
+   from redback_jax.sources import PrecomputedSpectraSource
+
+   source = PrecomputedSpectraSource(
+       phases=output.time,
+       wavelengths=output.lambdas,
+       flux_grid=output.spectra,
+   )
+
+   bridges, band_to_idx = source.prepare_bridges(['ztfg', 'ztfr'])
+   band_indices = jnp.array([band_to_idx[b] for b in observed_bands])
+
+   model_fluxes = source.bandflux(
+       {'amplitude': 1.0}, None, obs_times,
+       band_indices=band_indices, bridges=bridges,
+       unique_bands=['ztfg', 'ztfr'],
+   )
+
+Available models
+----------------
+
+**Supernovae**
+
+- ``arnett_bolometric`` — Ni/Co decay + Arnett diffusion (Arnett 1982)
+- ``magnetar_powered_bolometric`` — dipole spin-down + Arnett diffusion
+- ``csm_interaction_bolometric`` — forward/reverse shocks + CSM diffusion
+
+**TDE**
+
+- ``tde_analytical_bolometric`` — t⁻⁵/³ fallback + Arnett diffusion
+
+  Note: parameter is ``log10_l0`` (not ``l0``), because the linear value
+  (~10⁴³ erg/s) overflows float32.
+
+**Shock-powered**
+
+- ``shock_cooling_bolometric`` — Piro 2021
+
+  Parameters ``log10_mass``, ``log10_radius``, ``log10_energy`` (log10 of
+  solar masses, cm, erg respectively), plus ``nn`` (outer density slope),
+  ``delta`` (inner density slope), ``kappa`` (opacity in cm²/g).
+
+- ``shocked_cocoon_bolometric`` — Piro & Kollmeier 2018
+
+**Kilonova**
+
+- ``metzger_kilonova_bolometric`` — r-process ODE, 200-shell (Metzger 2017)
+- ``magnetar_boosted_kilonova_bolometric`` — r-process + magnetar injection
+
+All models are ``@jax.jit`` compiled and support ``jax.grad`` and ``jax.vmap``.
+
+Next steps
 ----------
 
-* Check out the :doc:`api` documentation for detailed function references
-* Explore :doc:`examples` for common use cases
-* See :doc:`contributing` for development guidelines
+* See :doc:`examples` for complete inference examples
+* See :doc:`api` for full function signatures

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "redback-jax"
-version = "0.1.0"
+version = "0.3.0"
 description = "A lightweight JAX-only version of redback for electromagnetic transient analysis"
 readme = "README.md"
 license = {text = "GPL-3.0"}


### PR DESCRIPTION
## Summary

- Bump version to 0.3.0
- Update README examples to use the clean `Prior`/`Likelihood`/`NestedSampler`/`MCMCSampler` API with `luminosity_distance_cm`
- Update docs (`examples.rst`, `quickstart.rst`) to fix broken JIT pattern, remove `vej_kms` typo, and show current inference API

## What's in v0.3

- Clean inference API: `Prior`, `Likelihood`, `NestedSampler`, `MCMCSampler`
- `MCMCSampler` using BlackJAX NUTS with `jax.lax.scan`
- `PrecomputedSpectraSource` rewritten as thin wrapper around `jax_supernovae.TimeSeriesSource` (correct AB magnitudes)
- `redback_jax.utils.cosmology` — `luminosity_distance_cm`, `PLANCK18_H0/OM0` constants
- All examples moved to `examples/`, float32 throughout (no `jax_enable_x64`)
- Codecov badge and CI token