### PR TITLE
add docker files

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,47 @@
+# Build the redback-jax runtime containers as a CI check.
+#
+# Build ONLY — this validates that both Dockerfiles build (deps resolve, the
+# handley-lab blackjax fork installs, `import redback_jax, jax, blackjax`
+# succeeds). It does NOT log in to or push to any registry; publishing is a
+# manual step.
+name: Build Docker image
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  docker-build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - dockerfile: containers/Dockerfile
+            tag: redback-jax:ci
+          - dockerfile: containers/Dockerfile.gpu
+            tag: redback-jax-gpu:ci
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image (no push)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64
+          push: false
+          tags: ${{ matrix.tag }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -11,20 +11,20 @@ RUN apt-get update \
 
 RUN pip3 install uv
 
+# External deps first (heavy wheels + a remote git checkout) so a local source
+# change doesn't invalidate their cache layer. JAX (CPU), then the handley-lab
+# nested-sampling blackjax fork the NestedSampler needs — pinned to a commit for
+# reproducible builds — plus anesthetic. NOT the [inference]/[all] extra (below):
+# it pins PyPI blackjax (>=1.0), a *different* package from this fork.
+RUN uv pip install --system --break-system-packages jax
+RUN uv pip install --system --break-system-packages \
+      "blackjax @ git+https://github.com/handley-lab/blackjax@2180e29ffb645b2c46b76c768229c7c24212446c" \
+      anesthetic
+
+# redback-jax core last (pulls diffrax, jax-bandflux, unxt, wcosmo, ...).
 WORKDIR /src
 COPY . /src
-
-# JAX (CPU) first so a JAX problem is isolated from the package install.
-RUN uv pip install --system --break-system-packages jax
-
-# redback-jax core (pulls diffrax, jax-bandflux, unxt, wcosmo, ...).
-# NOT the [inference]/[all] extra: it pins PyPI blackjax (>=1.0), a *different*
-# package from the handley-lab nested-sampling fork that NestedSampler needs.
-# Install the fork explicitly afterwards so it wins.
 RUN uv pip install --system --break-system-packages .
-RUN uv pip install --system --break-system-packages \
-      "blackjax @ git+https://github.com/handley-lab/blackjax@nested_sampling" \
-      anesthetic
 
 # Fail the build if the runtime + nested-sampling API aren't importable.
 RUN python3 -c "import redback_jax, jax, blackjax; from blackjax.ns.utils import log_weights; print('redback-jax + jax', jax.__version__, '+ blackjax(NS)', blackjax.__version__)"

--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -1,0 +1,32 @@
+# CPU runtime image for redback-jax.
+# Build (context = repo root): docker build -f containers/Dockerfile -t redback-jax:latest .
+# GPU variant: containers/Dockerfile.gpu (jax[cuda12]).
+FROM ubuntu:24.04
+
+ENV PIP_BREAK_SYSTEM_PACKAGES=1 DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+ && apt-get install -y python3 python3-pip git build-essential \
+ && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+RUN pip3 install uv
+
+WORKDIR /src
+COPY . /src
+
+# JAX (CPU) first so a JAX problem is isolated from the package install.
+RUN uv pip install --system --break-system-packages jax
+
+# redback-jax core (pulls diffrax, jax-bandflux, unxt, wcosmo, ...).
+# NOT the [inference]/[all] extra: it pins PyPI blackjax (>=1.0), a *different*
+# package from the handley-lab nested-sampling fork that NestedSampler needs.
+# Install the fork explicitly afterwards so it wins.
+RUN uv pip install --system --break-system-packages .
+RUN uv pip install --system --break-system-packages \
+      "blackjax @ git+https://github.com/handley-lab/blackjax@nested_sampling" \
+      anesthetic
+
+# Fail the build if the runtime + nested-sampling API aren't importable.
+RUN python3 -c "import redback_jax, jax, blackjax; from blackjax.ns.utils import log_weights; print('redback-jax + jax', jax.__version__, '+ blackjax(NS)', blackjax.__version__)"
+
+CMD ["python3"]

--- a/containers/Dockerfile.gpu
+++ b/containers/Dockerfile.gpu
@@ -1,0 +1,35 @@
+# GPU runtime image for redback-jax (jax[cuda12]).
+# Same as containers/Dockerfile but CUDA JAX so the float32-safe models run on a
+# GPU worker. Distributed via CVMFS (no per-job pull), which matters here: the
+# CUDA wheels make this image multi-GB.
+# Build (context = repo root): docker build -f containers/Dockerfile.gpu -t redback-jax-gpu:latest .
+FROM ubuntu:24.04
+
+ENV PIP_BREAK_SYSTEM_PACKAGES=1 DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+ && apt-get install -y python3 python3-pip git build-essential \
+ && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+RUN pip3 install uv
+
+WORKDIR /src
+COPY . /src
+
+# CUDA JAX first: the jax[cuda12] wheels bundle CUDA 12 + cuDNN, so only a host
+# driver is needed at runtime. cuda12 (not 13) matches the broadest GPU-node
+# driver pool. Isolate a GPU problem from the package install by doing it first.
+RUN uv pip install --system --break-system-packages "jax[cuda12]"
+
+# redback-jax core + the handley-lab nested-sampling blackjax fork (see the
+# non-GPU Dockerfile for why the [inference] extra is avoided).
+RUN uv pip install --system --break-system-packages .
+RUN uv pip install --system --break-system-packages \
+      "blackjax @ git+https://github.com/handley-lab/blackjax@nested_sampling" \
+      anesthetic
+
+# Import check: pin JAX to CPU so the GPU-less builder doesn't fail on cuInit
+# (at runtime on a GPU node, JAX auto-selects CUDA).
+RUN JAX_PLATFORMS=cpu python3 -c "import redback_jax, jax, blackjax; from blackjax.ns.utils import log_weights; print('redback-jax + jax', jax.__version__)"
+
+CMD ["python3"]

--- a/containers/Dockerfile.gpu
+++ b/containers/Dockerfile.gpu
@@ -13,23 +13,24 @@ RUN apt-get update \
 
 RUN pip3 install uv
 
+# External deps first (heavy wheels + a remote git checkout) so a local source
+# change doesn't invalidate their cache layer. The jax[cuda12] wheels bundle
+# CUDA 12 + cuDNN, so only a host driver is needed at runtime; cuda12 (not 13)
+# matches the broadest GPU-node driver pool. Then the handley-lab nested-sampling
+# blackjax fork (pinned to a commit for reproducible builds) + anesthetic. NOT the
+# [inference]/[all] extra (below): it pins PyPI blackjax, a different package.
+RUN uv pip install --system --break-system-packages "jax[cuda12]"
+RUN uv pip install --system --break-system-packages \
+      "blackjax @ git+https://github.com/handley-lab/blackjax@2180e29ffb645b2c46b76c768229c7c24212446c" \
+      anesthetic
+
+# redback-jax core last (pulls diffrax, jax-bandflux, unxt, wcosmo, ...).
 WORKDIR /src
 COPY . /src
-
-# CUDA JAX first: the jax[cuda12] wheels bundle CUDA 12 + cuDNN, so only a host
-# driver is needed at runtime. cuda12 (not 13) matches the broadest GPU-node
-# driver pool. Isolate a GPU problem from the package install by doing it first.
-RUN uv pip install --system --break-system-packages "jax[cuda12]"
-
-# redback-jax core + the handley-lab nested-sampling blackjax fork (see the
-# non-GPU Dockerfile for why the [inference] extra is avoided).
 RUN uv pip install --system --break-system-packages .
-RUN uv pip install --system --break-system-packages \
-      "blackjax @ git+https://github.com/handley-lab/blackjax@nested_sampling" \
-      anesthetic
 
 # Import check: pin JAX to CPU so the GPU-less builder doesn't fail on cuInit
 # (at runtime on a GPU node, JAX auto-selects CUDA).
-RUN JAX_PLATFORMS=cpu python3 -c "import redback_jax, jax, blackjax; from blackjax.ns.utils import log_weights; print('redback-jax + jax', jax.__version__)"
+RUN JAX_PLATFORMS=cpu python3 -c "import redback_jax, jax, blackjax; from blackjax.ns.utils import log_weights; print('redback-jax + jax', jax.__version__, '+ blackjax(NS)', blackjax.__version__)"
 
 CMD ["python3"]


### PR DESCRIPTION
This PR adds Docker files to redback-jax, with the goal of them appearing on Dockerhub and eventually https://github.com/opensciencegrid/cvmfs-singularity-sync so that we could trigger fitting jobs from SkyPortal.

Happy to discuss @nikhil-sarin.