### PR TITLE
Use mainline blackjax for SMC sampling instead of the NS fork

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -5,7 +5,8 @@
 # the handley-lab blackjax fork installs, `import redback_jax, jax, blackjax`
 # succeeds) WITHOUT pushing anywhere. On pushes to main, it additionally logs
 # in to Docker Hub and pushes nsarinastro/redback-jax:latest (CPU) and
-# nsarinastro/redback-jax:gpu. Requires repo secrets DOCKERHUB_USERNAME and
+# nsarinastro/redback-jax:gpu -- ONLY on the upstream nikhil-sarin/redback-jax
+# repo, so forks just build-check. Requires repo secrets DOCKERHUB_USERNAME and
 # DOCKERHUB_TOKEN (a Docker Hub access token with Read/Write scope).
 name: Build Docker image
 
@@ -41,7 +42,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to Docker Hub
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.repository == 'nikhil-sarin/redback-jax' && github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -53,7 +54,7 @@ jobs:
           context: .
           file: ${{ matrix.dockerfile }}
           platforms: linux/amd64
-          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-          tags: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && matrix.tag || matrix.ci_tag }}
+          push: ${{ github.repository == 'nikhil-sarin/redback-jax' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+          tags: ${{ (github.repository == 'nikhil-sarin/redback-jax' && github.event_name == 'push' && github.ref == 'refs/heads/main') && matrix.tag || matrix.ci_tag }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -11,15 +11,12 @@ RUN apt-get update \
 
 RUN pip3 install uv
 
-# External deps first (heavy wheels + a remote git checkout) so a local source
-# change doesn't invalidate their cache layer. JAX (CPU), then the handley-lab
-# nested-sampling blackjax fork the NestedSampler needs — pinned to a commit for
-# reproducible builds — plus anesthetic. NOT the [inference]/[all] extra (below):
-# it pins PyPI blackjax (>=1.0), a *different* package from this fork.
+# External deps first (heavy wheels) so a local source change doesn't invalidate
+# their cache layer. JAX (CPU), then mainline blackjax for the SMC+NUTS sampler
+# used via run_nested_sampling. (The handley-lab nested-sampling fork is avoided:
+# its older JAX API breaks on current JAX, and mainline SMC still gives evidence.)
 RUN uv pip install --system --break-system-packages jax
-RUN uv pip install --system --break-system-packages \
-      "blackjax @ git+https://github.com/handley-lab/blackjax@2180e29ffb645b2c46b76c768229c7c24212446c" \
-      anesthetic
+RUN uv pip install --system --break-system-packages blackjax
 
 # redback-jax core last (pulls diffrax, jax-bandflux, unxt, wcosmo, ...).
 WORKDIR /src
@@ -27,6 +24,6 @@ COPY . /src
 RUN uv pip install --system --break-system-packages .
 
 # Fail the build if the runtime + nested-sampling API aren't importable.
-RUN python3 -c "import redback_jax, jax, blackjax; from blackjax.ns.utils import log_weights; print('redback-jax + jax', jax.__version__, '+ blackjax(NS)', blackjax.__version__)"
+RUN python3 -c "import redback_jax, jax, blackjax; assert hasattr(blackjax, 'nuts'); print('redback-jax + jax', jax.__version__, '+ blackjax', blackjax.__version__)"
 
 CMD ["python3"]

--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -16,7 +16,7 @@ RUN pip3 install uv
 # used via run_nested_sampling. (The handley-lab nested-sampling fork is avoided:
 # its older JAX API breaks on current JAX, and mainline SMC still gives evidence.)
 RUN uv pip install --system --break-system-packages jax
-RUN uv pip install --system --break-system-packages blackjax
+RUN uv pip install --system --break-system-packages blackjax anesthetic
 
 # redback-jax core last (pulls diffrax, jax-bandflux, unxt, wcosmo, ...).
 WORKDIR /src
@@ -24,6 +24,6 @@ COPY . /src
 RUN uv pip install --system --break-system-packages .
 
 # Fail the build if the runtime + nested-sampling API aren't importable.
-RUN python3 -c "import redback_jax, jax, blackjax; assert hasattr(blackjax, 'nuts'); print('redback-jax + jax', jax.__version__, '+ blackjax', blackjax.__version__)"
+RUN python3 -c "import redback_jax, jax, blackjax; from redback_jax.inference.sampler import run_nested_sampling; print('redback-jax + jax', jax.__version__, '+ blackjax', blackjax.__version__)"
 
 CMD ["python3"]

--- a/containers/Dockerfile.gpu
+++ b/containers/Dockerfile.gpu
@@ -17,12 +17,10 @@ RUN pip3 install uv
 # change doesn't invalidate their cache layer. The jax[cuda12] wheels bundle
 # CUDA 12 + cuDNN, so only a host driver is needed at runtime; cuda12 (not 13)
 # matches the broadest GPU-node driver pool. Then the handley-lab nested-sampling
-# blackjax fork (pinned to a commit for reproducible builds) + anesthetic. NOT the
-# [inference]/[all] extra (below): it pins PyPI blackjax, a different package.
+# mainline blackjax for the SMC+NUTS sampler used via run_nested_sampling (the
+# handley-lab NS fork is avoided: its older JAX API breaks on current JAX).
 RUN uv pip install --system --break-system-packages "jax[cuda12]"
-RUN uv pip install --system --break-system-packages \
-      "blackjax @ git+https://github.com/handley-lab/blackjax@2180e29ffb645b2c46b76c768229c7c24212446c" \
-      anesthetic
+RUN uv pip install --system --break-system-packages blackjax
 
 # redback-jax core last (pulls diffrax, jax-bandflux, unxt, wcosmo, ...).
 WORKDIR /src
@@ -31,6 +29,6 @@ RUN uv pip install --system --break-system-packages .
 
 # Import check: pin JAX to CPU so the GPU-less builder doesn't fail on cuInit
 # (at runtime on a GPU node, JAX auto-selects CUDA).
-RUN JAX_PLATFORMS=cpu python3 -c "import redback_jax, jax, blackjax; from blackjax.ns.utils import log_weights; print('redback-jax + jax', jax.__version__, '+ blackjax(NS)', blackjax.__version__)"
+RUN JAX_PLATFORMS=cpu python3 -c "import redback_jax, jax, blackjax; assert hasattr(blackjax, 'nuts'); print('redback-jax + jax', jax.__version__, '+ blackjax', blackjax.__version__)"
 
 CMD ["python3"]

--- a/containers/Dockerfile.gpu
+++ b/containers/Dockerfile.gpu
@@ -20,7 +20,7 @@ RUN pip3 install uv
 # mainline blackjax for the SMC+NUTS sampler used via run_nested_sampling (the
 # handley-lab NS fork is avoided: its older JAX API breaks on current JAX).
 RUN uv pip install --system --break-system-packages "jax[cuda12]"
-RUN uv pip install --system --break-system-packages blackjax
+RUN uv pip install --system --break-system-packages blackjax anesthetic
 
 # redback-jax core last (pulls diffrax, jax-bandflux, unxt, wcosmo, ...).
 WORKDIR /src
@@ -29,6 +29,6 @@ RUN uv pip install --system --break-system-packages .
 
 # Import check: pin JAX to CPU so the GPU-less builder doesn't fail on cuInit
 # (at runtime on a GPU node, JAX auto-selects CUDA).
-RUN JAX_PLATFORMS=cpu python3 -c "import redback_jax, jax, blackjax; assert hasattr(blackjax, 'nuts'); print('redback-jax + jax', jax.__version__, '+ blackjax', blackjax.__version__)"
+RUN JAX_PLATFORMS=cpu python3 -c "import redback_jax, jax, blackjax; from redback_jax.inference.sampler import run_nested_sampling; print('redback-jax + jax', jax.__version__, '+ blackjax', blackjax.__version__)"
 
 CMD ["python3"]


### PR DESCRIPTION
Which allows us to use a modern Jax.